### PR TITLE
Eliminate need for param store serialization

### DIFF
--- a/2019-08-time-series/bart/Makefile
+++ b/2019-08-time-series/bart/Makefile
@@ -6,28 +6,24 @@ lint: FORCE
 test: lint FORCE
 	python main.py -n 2 -v \
 	  --truncate=168 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
 	python main.py -n 2 -v \
 	  --analytic-kl \
 	  --truncate=168 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
 	python main.py -n 2 -v \
 	  --funsor \
 	  --truncate=168 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
 	python main.py -n 2 -v \
 	  --mean-field \
 	  --truncate=168 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
@@ -37,7 +33,6 @@ profile: lint FORCE
 	python -m cProfile -o forecast.prof main.py -n 1 \
 	  --funsor \
 	  --truncate=128 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
@@ -50,7 +45,6 @@ test2: lint FORCE
 	  --truncate=2 \
 	  --state-dim=2 \
 	  --guide-rank=2 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
@@ -64,7 +58,6 @@ test3: lint FORCE
 	  --truncate=2 \
 	  --state-dim=2 \
 	  --guide-rank=2 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null
@@ -77,7 +70,6 @@ test4: lint FORCE
 	  --truncate=2 \
 	  --state-dim=2 \
 	  --guide-rank=2 \
-	  --param-store-filename=/dev/null \
 	  --forecaster-filename=/dev/null \
 	  --forecast-filename=/dev/null \
 	  --training-filename=/dev/null

--- a/2019-08-time-series/bart/evaluate.py
+++ b/2019-08-time-series/bart/evaluate.py
@@ -54,7 +54,6 @@ def forecast_one(args, config):
         command.append(f'--num-steps={args.num_steps}')
         command.append(f'--forecast-hours={args.forecast_hours}')
         command.append(f'--num-samples={args.num_samples}')
-        command.append('--param-store-filename=/dev/null')
         command.append('--forecaster-filename=/dev/null')
         command.append('--training-filename=/dev/null')
         command.extend(config)

--- a/2019-08-time-series/bart/forecast.ipynb
+++ b/2019-08-time-series/bart/forecast.ipynb
@@ -109,7 +109,6 @@
     }
    ],
    "source": [
-    "pyro.get_param_store().load(\"pyro_param_store.pkl\", map_location=\"cpu\")\n",
     "forecaster = torch.load(\"forecaster.pkl\", map_location=\"cpu\")\n",
     "forecaster.args.device = \"cpu\"\n",
     "print(type(forecaster))\n",

--- a/2019-08-time-series/bart/main.py
+++ b/2019-08-time-series/bart/main.py
@@ -9,7 +9,7 @@ from preprocess import load_hourly_od
 
 
 def main(args):
-    assert pyro.__version__ >= "0.4.1"
+    assert pyro.__version__ > "0.5.1"
     pyro.enable_validation(__debug__)
     pyro.set_rng_seed(args.seed)
     dataset = load_hourly_od(args)

--- a/2019-08-time-series/bart/main.py
+++ b/2019-08-time-series/bart/main.py
@@ -36,7 +36,6 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="BART origin-destination forecast")
-    parser.add_argument("--param-store-filename", default="pyro_param_store.pkl")
     parser.add_argument("--forecaster-filename", default="forecaster.pkl")
     parser.add_argument("--forecast-filename", default="forecast.pkl")
     parser.add_argument("--training-filename", default="training.pkl")


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/pyro/issues/2078
Blocked by Pyro release https://github.com/pyro-ppl/pyro/milestone/10

This demonstrates an idiom to avoid the need for param store serialization. By avoiding the `pyro.param` statement and relying entirely on `pyro.module` we can use PyTorch's native module serialization.